### PR TITLE
/keycontainer support

### DIFF
--- a/ILMerge.Tests/Helpers/CspContainerUtils.cs
+++ b/ILMerge.Tests/Helpers/CspContainerUtils.cs
@@ -1,0 +1,46 @@
+﻿using System.Security.Cryptography;
+
+namespace ILMerging.Tests.Helpers
+{
+    public static class CspContainerUtils
+    {
+        public static void ImportBlob(bool machineLevel, string containerName, KeyNumber keyNumber, byte[] blob)
+        {
+            using (var rspCsp = new RSACryptoServiceProvider(new CspParameters
+            {
+                KeyContainerName = containerName,
+                KeyNumber = (int)keyNumber,
+                Flags = machineLevel ? CspProviderFlags.UseMachineKeyStore : 0
+            }))
+            {
+                rspCsp.ImportCspBlob(blob);
+            }
+        }
+
+        public static byte[] ExportBlob(bool machineLevel, string containerName, KeyNumber keyNumber, bool includePrivateParameters)
+        {
+            using (var rspCsp = new RSACryptoServiceProvider(new CspParameters
+            {
+                KeyContainerName = containerName,
+                KeyNumber = (int)keyNumber,
+                Flags = CspProviderFlags.UseExistingKey | (machineLevel ? CspProviderFlags.UseMachineKeyStore : 0)
+            }))
+            {
+                return rspCsp.ExportCspBlob(includePrivateParameters);
+            }
+        }
+
+        public static void Delete(bool machineLevel, string containerName, KeyNumber keyNumber)
+        {
+            using (var rspCsp = new RSACryptoServiceProvider(new CspParameters
+            {
+                KeyContainerName = containerName,
+                KeyNumber = (int)keyNumber,
+                Flags = machineLevel ? CspProviderFlags.UseMachineKeyStore : 0
+            }))
+            {
+                rspCsp.PersistKeyInCsp = false;
+            }
+        }
+    }
+}

--- a/ILMerge.Tests/ILMerge.Tests.csproj
+++ b/ILMerge.Tests/ILMerge.Tests.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="BaselineTests.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="Helpers\CspContainerUtils.cs" />
     <Compile Include="Integration\ConsoleTests.cs" />
     <Compile Include="Helpers\ShadowCopyUtils.cs" />
     <Compile Include="Helpers\ProcessUtils.cs" />

--- a/System.Compiler/Writer.cs
+++ b/System.Compiler/Writer.cs
@@ -5338,7 +5338,8 @@ namespace System.Compiler{
       module.Directory = Path.GetDirectoryName(location);
       bool keyFileNameDoesNotExist = false;
       if (assem != null){
-        assem.KeyContainerName = keyName;
+        if (keyName != null)
+          assem.KeyContainerName = keyName;
         if (keyFileName != null && keyFileName.Length > 0){
           if (!File.Exists(keyFileName)) keyFileName = Path.Combine(module.Directory, keyFileName);
           if (File.Exists(keyFileName)){


### PR DESCRIPTION
[Per email conversation.]

Adds `/keycontainer` support, bringing ILMerge on par with csc.exe and ILRepack and making general MSBuild targets possible.