### PR TITLE
Fix links in ILMerge.nuspec

### DIFF
--- a/ILMerge/ILMerge.nuspec
+++ b/ILMerge/ILMerge.nuspec
@@ -8,8 +8,8 @@
     <authors>mbarnett</authors>
     <owners>mbarnett</owners>
     <copyright>Microsoft Corporation</copyright>
-    <licenseUrl>http://research.microsoft.com/en-us/people/mbarnett/ilmerge-license.aspx</licenseUrl>
-    <projectUrl>https://www.microsoft.com/en-us/research/people/mbarnett/#ilmerge</projectUrl>
+    <licenseUrl>https://www.microsoft.com/en-us/research/people/mbarnett/#!ilmerge-license</licenseUrl>
+    <projectUrl>https://www.microsoft.com/en-us/research/people/mbarnett/#!ilmerge</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <summary>ILMerge is a static linker for .NET assemblies.</summary>
     <description>ILMerge is a utility that can be used to merge multiple .NET assemblies into a single assembly. ILMerge takes a set of input assemblies and merges them into one target assembly. The first assembly in the list of input assemblies is the primary assembly. When the primary assembly is an executable, then the target assembly is created as an executable with the same entry point as the primary assembly. Also, if the primary assembly has a strong name, and a .snk file is provided, then the target assembly is re-signed with the specified key so that it also has a strong name.

--- a/ILMerge/ILMerge.nuspec
+++ b/ILMerge/ILMerge.nuspec
@@ -8,8 +8,8 @@
     <authors>mbarnett</authors>
     <owners>mbarnett</owners>
     <copyright>Microsoft Corporation</copyright>
-    <licenseUrl>https://www.microsoft.com/en-us/research/people/mbarnett/#!ilmerge-license</licenseUrl>
-    <projectUrl>https://www.microsoft.com/en-us/research/people/mbarnett/#!ilmerge</projectUrl>
+    <licenseUrl>https://github.com/dotnet/ILMerge/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/dotnet/ILMerge</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <summary>ILMerge is a static linker for .NET assemblies.</summary>
     <description>ILMerge is a utility that can be used to merge multiple .NET assemblies into a single assembly. ILMerge takes a set of input assemblies and merges them into one target assembly. The first assembly in the list of input assemblies is the primary assembly. When the primary assembly is an executable, then the target assembly is created as an executable with the same entry point as the primary assembly. Also, if the primary assembly has a strong name, and a .snk file is provided, then the target assembly is re-signed with the specified key so that it also has a strong name.
@@ -17,7 +17,7 @@
 ILMerge is packaged as a console application. But all of its functionality is also available programmatically.
 
 There are several options that control the behavior of ILMerge. See the documentation that comes with the tool for details.</description>
-    <repository type="git" url="https://github.com/Microsoft/ILMerge" />
+    <repository type="git" url="https://github.com/dotnet/ILMerge" />
   </metadata>
   <files>
     <file src="bin/$configuration$/net452/final/ILMerge.exe" target="tools/net452/ILMerge.exe" />


### PR DESCRIPTION
Fix `<licenseUrl/>` and `<projectUrl/>`.