### PR TITLE
Fixed invalid RT_GROUP_ICON when adding icons directly from the Writer class

### DIFF
--- a/System.Compiler/Writer.cs
+++ b/System.Compiler/Writer.cs
@@ -5470,8 +5470,8 @@ namespace System.Compiler{
         indexHeap.Write(cursor.ReadUInt16()); //bit count
         int len = cursor.ReadInt32();
         int offset = cursor.ReadInt32();
-        indexHeap.Write((int)len);
-        indexHeap.Write((int)module.Win32Resources.Count+2);
+        indexHeap.Write((uint)len);
+        indexHeap.Write((ushort)(module.Win32Resources.Count+2));
         MemoryCursor c = new MemoryCursor(cursor);
         c.Position = offset;
         resource.Data = c.ReadBytes(len);


### PR DESCRIPTION
Resource type RT_GROUP_ICON weren't written properly when calling the AddWin32Icon methods on the Writer class, the ID of each GRPICONDIRENTRY were written as an INT instead of a USHORT.