### PR TITLE
Issue67: Allow "this" to be passed by reference (to methods that use the "in" modifier on the parameter)

### DIFF
--- a/System.Compiler/Writer.cs
+++ b/System.Compiler/Writer.cs
@@ -2757,7 +2757,7 @@ namespace System.Compiler{
         case NodeType.Parameter:
         case NodeType.This:
 #if !MinimalReader
-                    ParameterBinding pb = operand as ParameterBinding;
+          ParameterBinding pb = operand as ParameterBinding;
           if (pb != null) operand = pb.BoundParameter;
 #endif
           int pi = ((Parameter)operand).ArgumentListIndex;

--- a/System.Compiler/Writer.cs
+++ b/System.Compiler/Writer.cs
@@ -2754,9 +2754,10 @@ namespace System.Compiler{
           }
           this.methodBodyHeap.Write((int)this.GetFieldToken((Field)mb.BoundMember));
           return;
-        case NodeType.Parameter: 
+        case NodeType.Parameter:
+        case NodeType.This:
 #if !MinimalReader
-          ParameterBinding pb = operand as ParameterBinding;
+                    ParameterBinding pb = operand as ParameterBinding;
           if (pb != null) operand = pb.BoundParameter;
 #endif
           int pi = ((Parameter)operand).ArgumentListIndex;


### PR DESCRIPTION
Fix Writer.cs so that "this" can have its address taken just as other parameters already could have. A small repro that illustrates this is: 

`public class C {
  public void Foo(int x) { Bar(this, x); }
  public void Bar(in C c, in int y){}
}
`

Both arguments are passed by reference.
